### PR TITLE
add pyproject.toml homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Kannon is a wrapper for the gokart library that allows gokart tas
 authors = ["M3, inc."]
 license = "MIT"
 readme = "README.md"
+homepage = "https://github.com/m3dev/kannon"
+repository = "https://github.com/m3dev/kannon"
 
 
 [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
A small improvement. I found that there is no Homepage link on the PyPI page https://pypi.org/project/kannon/ 

When we have doc page let's add `documentation` item as well. We can also add `keyword` and `classifier` but this PR doesn't cover those.

ref:
* https://github.com/m3dev/gokart/blob/master/pyproject.toml
* https://python-poetry.org/docs/pyproject/