### PR TITLE
flatten requires

### DIFF
--- a/kannon/master.py
+++ b/kannon/master.py
@@ -6,6 +6,7 @@ from typing import Deque, Dict, List, Set, Optional
 import logging
 
 import gokart
+from luigi.task import flatten
 from kubernetes import client
 
 from .task import TaskOnBullet
@@ -85,9 +86,7 @@ class Kannon:
             """Traversal task tree in post-order to push tasks into task queue."""
             nonlocal task_queue
             # run children
-            children = task.requires()
-            if isinstance(children, dict):
-                children = children.values()
+            children = flatten(task.requires())
             for child in children:
                 _rec_enqueue_task(child)
 
@@ -147,9 +146,7 @@ class Kannon:
         return f"{task.get_task_family()}_{task.make_unique_id()}"
 
     def _is_executable(self, task: gokart.TaskOnKart) -> bool:
-        children = task.requires()
-        if isinstance(children, dict):
-            children = children.values()
+        children = flatten(task.requires())
 
         for child in children:
             if not child.complete():

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -1,0 +1,42 @@
+import unittest
+
+import gokart
+from kannon import Kannon
+
+class TestStringMethods(unittest.TestCase):
+    def test_create_task_queue(self):
+        class Example(gokart.TaskOnKart):
+            pass
+
+        class Dict(gokart.TaskOnKart):
+            def requires(self):
+                return dict(example=Example())
+        class List(gokart.TaskOnKart):
+            def requires(self):
+                return [Example()]
+        class ListInDict(gokart.TaskOnKart):
+            def requires(self):
+                return dict(example=[Example()])
+
+        class Single(gokart.TaskOnKart):
+            def requires(self):
+                return Example()
+
+        cases = [Dict(), List(), ListInDict(), Single()]
+        for case in cases:
+            with self.subTest(case=case):
+                master = Kannon(
+                    api_instance=None,
+                    namespace=None,
+                    image_name=None,
+                    container_name=None,
+                    job_prefix=None,
+                    path_child_script=__file__,
+                    env_to_inherit=None,
+                    service_account_name=None,
+                )
+                master._create_task_queue(case)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -1,24 +1,35 @@
 import unittest
 
 import gokart
+from kubernetes import client
+
 from kannon import Kannon
 
+
 class TestStringMethods(unittest.TestCase):
+
     def test_create_task_queue(self):
+
         class Example(gokart.TaskOnKart):
             pass
 
         class Dict(gokart.TaskOnKart):
+
             def requires(self):
                 return dict(example=Example())
+
         class List(gokart.TaskOnKart):
+
             def requires(self):
                 return [Example()]
+
         class ListInDict(gokart.TaskOnKart):
+
             def requires(self):
                 return dict(example=[Example()])
 
         class Single(gokart.TaskOnKart):
+
             def requires(self):
                 return Example()
 
@@ -27,13 +38,10 @@ class TestStringMethods(unittest.TestCase):
             with self.subTest(case=case):
                 master = Kannon(
                     api_instance=None,
-                    namespace=None,
-                    image_name=None,
-                    container_name=None,
+                    template_job=client.V1Job(metadata=client.V1ObjectMeta()),
                     job_prefix=None,
-                    path_child_script=__file__,
+                    path_child_script=__file__,  # just pass any existing file as dummy
                     env_to_inherit=None,
-                    service_account_name=None,
                 )
                 master._create_task_queue(case)
 


### PR DESCRIPTION
Current master can't handle some types of `requires()` return value. This PR fixes it.


If run my test cases with main branch:

```
test_create_task_queue (test.test_master.TestStringMethods.test_create_task_queue) ...
  test_create_task_queue (test.test_master.TestStringMethods.test_create_task_queue) (case=ListInDict()) ... ERROR
  test_create_task_queue (test.test_master.TestStringMethods.test_create_task_queue) (case=Single()) ... ERROR

======================================================================
ERROR: test_create_task_queue (test.test_master.TestStringMethods.test_create_task_queue) (case=ListInDict())
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/kannon/test/test_master.py", line 38, in test_create_task_queue
    master._create_task_queue(case)
  File "/workspace/kannon/kannon/master.py", line 110, in _create_task_queue
    _rec_enqueue_task(root_task)
  File "/workspace/kannon/kannon/master.py", line 105, in _rec_enqueue_task
    _rec_enqueue_task(child)
  File "/workspace/kannon/kannon/master.py", line 101, in _rec_enqueue_task
    children = task.requires()
               ^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'requires'

======================================================================
ERROR: test_create_task_queue (test.test_master.TestStringMethods.test_create_task_queue) (case=Single())
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/kannon/test/test_master.py", line 38, in test_create_task_queue
    master._create_task_queue(case)
  File "/workspace/kannon/kannon/master.py", line 110, in _create_task_queue
    _rec_enqueue_task(root_task)
  File "/workspace/kannon/kannon/master.py", line 104, in _rec_enqueue_task
    for child in children:
TypeError: 'Example' object is not iterable

----------------------------------------------------------------------
```