### PR TITLE
Fix not wait first bullet bug

### DIFF
--- a/kannon/master.py
+++ b/kannon/master.py
@@ -61,7 +61,7 @@ class Kannon:
                 continue
 
             # TODO: enable user to specify duration to sleep for each task
-            sleep(0.1)
+            sleep(1.0)
             logger.info(f"Checking if task {self._gen_task_info(task)} is executable...")
             if not self._is_executable(task):
                 task_queue.append(task)  # re-enqueue task to check if it's executable later

--- a/kannon/master.py
+++ b/kannon/master.py
@@ -33,8 +33,7 @@ class Kannon:
 
         self.template_job = template_job
         self.api_instance = api_instance
-        namespace = template_job.metadata.namespace
-        self.namespace = "default" if namespace is None else namespace
+        self.namespace = template_job.metadata.namespace
         self.job_prefix = job_prefix
         self.path_child_script = path_child_script
         if env_to_inherit is None:
@@ -130,18 +129,16 @@ class Kannon:
         ]
         job = deepcopy(self.template_job)
         # replace command
-        original_command = job.spec.template.spec.containers[0].command
-        if original_command:
-            raise ValueError("command will be replaced by kannon, so you shouldn't set any command and args")
+        assert len(job.spec.template.spec.containers[0].command) == 0, \
+            "command will be replaced by kannon, so you shouldn't set any command and args"
         job.spec.template.spec.containers[0].command = cmd
         # replace env
-        original_env = job.spec.template.spec.containers[0].env
-        child_envs = [] if original_env is None else original_env
+        child_envs = []
         for env_name in self.env_to_inherit:
             if env_name not in os.environ:
                 raise ValueError(f"Envvar {env_name} does not exist.")
             child_envs.append({"name": env_name, "value": os.environ.get(env_name)})
-        job.spec.template.spec.containers[0].env = child_envs
+        job.spec.template.spec.containers[0].env.extend(child_envs)
         # replace job name
         job.metadata.name = job_name
 


### PR DESCRIPTION
## What
Fix bug #7 with some logging changes

### What caused the bug
After launching the first bullet task with a child job, the master did not re-enqueue the task.
In the case given in PR #7, it made the task queue empty, which resulted in termination.

### What is fixed
Fixed the above problems.
