### PR TITLE
Fix env and command replacement

### DIFF
--- a/kannon/master.py
+++ b/kannon/master.py
@@ -126,13 +126,13 @@ class Kannon:
         ]
         job = deepcopy(self.template_job)
         # replace command
-        original_command = job.spec.template.spec.containers[0].command
-        if original_command:
-            raise ValueError("command will be replaced by kannon, so you shouldn't set any command and args")
+        assert job.spec.template.spec.containers[0].command is None, \
+            "command will be replaced by kannon, so you shouldn't set any command and args"
         job.spec.template.spec.containers[0].command = cmd
         # replace env
-        original_env = job.spec.template.spec.containers[0].env
-        child_envs = [] if original_env is None else original_env
+        child_envs = job.spec.template.spec.containers[0].env
+        if not child_envs:
+            child_envs = []
         for env_name in self.env_to_inherit:
             if env_name not in os.environ:
                 raise ValueError(f"Envvar {env_name} does not exist.")

--- a/kannon/master.py
+++ b/kannon/master.py
@@ -126,16 +126,18 @@ class Kannon:
         ]
         job = deepcopy(self.template_job)
         # replace command
-        assert len(job.spec.template.spec.containers[0].command) == 0, \
-            "command will be replaced by kannon, so you shouldn't set any command and args"
+        original_command = job.spec.template.spec.containers[0].command
+        if original_command:
+            raise ValueError("command will be replaced by kannon, so you shouldn't set any command and args")
         job.spec.template.spec.containers[0].command = cmd
         # replace env
-        child_envs = []
+        original_env = job.spec.template.spec.containers[0].env
+        child_envs = [] if original_env is None else original_env
         for env_name in self.env_to_inherit:
             if env_name not in os.environ:
                 raise ValueError(f"Envvar {env_name} does not exist.")
             child_envs.append({"name": env_name, "value": os.environ.get(env_name)})
-        job.spec.template.spec.containers[0].env.extend(child_envs)
+        job.spec.template.spec.containers[0].env = child_envs
         # replace job name
         job.metadata.name = job_name
 

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -1,5 +1,5 @@
-import unittest
 import os
+import unittest
 
 import gokart
 from kubernetes import client

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import gokart
 from kubernetes import client
@@ -44,6 +45,130 @@ class TestStringMethods(unittest.TestCase):
                     env_to_inherit=None,
                 )
                 master._create_task_queue(case)
+
+
+class TestCreateChildJobObject(unittest.TestCase):
+
+    def _get_template_job(self) -> client.V1Job:
+        return client.V1Job(api_version="batch/v1",
+                            kind="Job",
+                            metadata=client.V1ObjectMeta(
+                                name="dummy-job-name",
+                                namespace="dummy-namespace",
+                            ),
+                            spec=client.V1JobSpec(template=client.V1PodTemplateSpec(spec=client.V1PodSpec(
+                                service_account_name="dummy-service-account",
+                                containers=[client.V1Container(
+                                    name="job",
+                                    image="dummy-image",
+                                )],
+                                restart_policy="Never",
+                            ))))
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        os.environ.clear()
+
+    def test_success_basic(self):
+
+        class Example(gokart.TaskOnKart):
+            pass
+
+        serialized_task = gokart.TaskInstanceParameter().serialize(Example())
+        template_job = self._get_template_job()
+        master = Kannon(
+            api_instance=None,
+            template_job=template_job,
+            job_prefix=None,
+            path_child_script=__file__,  # just pass any existing file as dummy
+            env_to_inherit=None,
+        )
+        # set os env
+        os.environ.update({"TASK_WORKSPACE_DIRECTORY": "/cache"})
+        child_job_name = "test-job"
+        child_job = master._create_child_job_object(child_job_name, serialized_task)
+
+        # following should be copied from template_job
+        self.assertEqual(child_job.api_version, template_job.api_version)
+        self.assertEqual(child_job.kind, template_job.kind)
+        self.assertEqual(child_job.metadata.namespace, template_job.metadata.namespace)
+        self.assertEqual(child_job.spec.template.spec.service_account_name, template_job.spec.template.spec.service_account_name)
+        self.assertEqual(child_job.spec.template.spec.containers[0].name, template_job.spec.template.spec.containers[0].name)
+        self.assertEqual(child_job.spec.template.spec.containers[0].image, template_job.spec.template.spec.containers[0].image)
+        self.assertEqual(child_job.spec.template.spec.restart_policy, template_job.spec.template.spec.restart_policy)
+        # following should be overwritten
+        self.assertEqual(child_job.spec.template.spec.containers[0].command, ["python", __file__, "--serialized-task", f"'{serialized_task}'"])
+        self.assertEqual(child_job.metadata.name, child_job_name)
+        # envvar TASK_WORKSPACE_DIRECTORY should be inherited
+        child_env = child_job.spec.template.spec.containers[0].env
+        self.assertEqual(len(child_env), 1)
+        self.assertEqual(child_env[0], {"name": "TASK_WORKSPACE_DIRECTORY", "value": "/cache"})
+
+    def test_success_custom_env(self):
+
+        class Example(gokart.TaskOnKart):
+            pass
+
+        serialized_task = gokart.TaskInstanceParameter().serialize(Example())
+        template_job = self._get_template_job()
+        master = Kannon(
+            api_instance=None,
+            template_job=template_job,
+            job_prefix=None,
+            path_child_script=__file__,  # just pass any existing file as dummy
+            env_to_inherit=["TASK_WORKSPACE_DIRECTORY", "MY_ENV0", "MY_ENV1"],
+        )
+        # set os env
+        os.environ.update({"TASK_WORKSPACE_DIRECTORY": "/cache", "MY_ENV0": "env0", "MY_ENV1": "env1"})
+        child_job_name = "test-job"
+        child_job = master._create_child_job_object(child_job_name, serialized_task)
+
+        child_env = child_job.spec.template.spec.containers[0].env
+        self.assertEqual(len(child_env), 3)
+        self.assertEqual(child_env[0], {"name": "TASK_WORKSPACE_DIRECTORY", "value": "/cache"})
+        self.assertEqual(child_env[1], {"name": "MY_ENV0", "value": "env0"})
+        self.assertEqual(child_env[2], {"name": "MY_ENV1", "value": "env1"})
+
+    def test_fail_command_set(self):
+
+        class Example(gokart.TaskOnKart):
+            pass
+
+        serialized_task = gokart.TaskInstanceParameter().serialize(Example())
+        template_job = self._get_template_job()
+        template_job.spec.template.spec.containers[0].command = ["dummy-command"]
+        master = Kannon(
+            api_instance=None,
+            template_job=template_job,
+            job_prefix=None,
+            path_child_script=__file__,  # just pass any existing file as dummy
+            env_to_inherit=None,
+        )
+        # set os env
+        os.environ.update({"TASK_WORKSPACE_DIRECTORY": "/cache"})
+        with self.assertRaises(AssertionError):
+            master._create_child_job_object("test-job", serialized_task)
+
+    def test_fail_default_env_not_exist(self):
+
+        class Example(gokart.TaskOnKart):
+            pass
+
+        serialized_task = gokart.TaskInstanceParameter().serialize(Example())
+        template_job = self._get_template_job()
+
+        cases = [None, ["TASK_WORKSPACE_DIRECTORY", "MY_ENV0", "MY_ENV1"]]
+        for case in cases:
+            with self.subTest(case=case):
+                master = Kannon(
+                    api_instance=None,
+                    template_job=template_job,
+                    job_prefix=None,
+                    path_child_script=__file__,  # just pass any existing file as dummy
+                    env_to_inherit=case,
+                )
+                with self.assertRaises(ValueError):
+                    master._create_child_job_object("test-job", serialized_task)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What
Fix a minor bug when `command` and `env` are replaced.

When replacing `command` and `env` in the template job, a minor bug exists.
When the template job's `command` or `env` is not explicitly set, they are evaluated `None`, which resulted in a value error.

ex:
```bash
 Traceback (most recent call last):
job-quick-starter-drwjj job   File "/usr/src/app/./run_batch.py", line 102, in <module>
job-quick-starter-drwjj job     fire.Fire(main)
job-quick-starter-drwjj job   File "/usr/local/lib/python3.9/site-packages/fire/core.py", line 141, in Fire
job-quick-starter-drwjj job     component_trace = _Fire(component, args, parsed_flag_args, context, name)
job-quick-starter-drwjj job   File "/usr/local/lib/python3.9/site-packages/fire/core.py", line 475, in _Fire
job-quick-starter-drwjj job     component, remaining_args = _CallAndUpdateTrace(
job-quick-starter-drwjj job   File "/usr/local/lib/python3.9/site-packages/fire/core.py", line 691, in _CallAndUpdateTrace
job-quick-starter-drwjj job     component = fn(*varargs, **kwargs)
job-quick-starter-drwjj job   File "/usr/src/app/./run_batch.py", line 94, in main
job-quick-starter-drwjj job     Kannon(
job-quick-starter-drwjj job   File "/usr/src/app/./kannon/kannon/master.py", line 73, in build
job-quick-starter-drwjj job     self._exec_bullet_task(task)
job-quick-starter-drwjj job   File "/usr/src/app/./kannon/kannon/master.py", line 113, in _exec_bullet_task
job-quick-starter-drwjj job     job = self._create_child_job_object(
job-quick-starter-drwjj job   File "/usr/src/app/./kannon/kannon/master.py", line 132, in _create_child_job_object
job-quick-starter-drwjj job     assert len(job.spec.template.spec.containers[0].command) == 0, \
job-quick-starter-drwjj job TypeError: object of type 'NoneType' has no len()
```