### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @maronuu @kitagry @yokomotod


### PR DESCRIPTION
I would like to add `CODEOWNERS` file in order to set reviewers by default.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.