### PR TITLE
[proposal] strict mypy

### DIFF
--- a/kannon/master.py
+++ b/kannon/master.py
@@ -42,7 +42,7 @@ class Kannon:
 
         self.task_id_to_job_name: Dict[str, str] = dict()
 
-    def build(self, root_task: gokart.TaskOnKart):
+    def build(self, root_task: gokart.TaskOnKart) -> None:
         # push tasks into queue
         logger.info("Creating task queue...")
         task_queue = self._create_task_queue(root_task)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ ignore_patterns = [
 line_length = 160
 
 [tool.mypy]
+strict = true
+disallow_subclassing_any = false  # revert strict
+implicit_reexport = true  # revert strict
 ignore_missing_imports = true
 
 [build-system]

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/test/test_master.py
+++ b/test/test_master.py
@@ -9,29 +9,29 @@ from kannon import Kannon
 
 class TestStringMethods(unittest.TestCase):
 
-    def test_create_task_queue(self):
+    def test_create_task_queue(self) -> None:
 
         class Example(gokart.TaskOnKart):
             pass
 
         class Dict(gokart.TaskOnKart):
 
-            def requires(self):
+            def requires(self) -> dict[str, Example]:
                 return dict(example=Example())
 
         class List(gokart.TaskOnKart):
 
-            def requires(self):
+            def requires(self) -> list[Example]:
                 return [Example()]
 
         class ListInDict(gokart.TaskOnKart):
 
-            def requires(self):
+            def requires(self) -> dict[str, list[Example]]:
                 return dict(example=[Example()])
 
         class Single(gokart.TaskOnKart):
 
-            def requires(self):
+            def requires(self) -> Example:
                 return Example()
 
         cases = [Dict(), List(), ListInDict(), Single()]
@@ -40,7 +40,7 @@ class TestStringMethods(unittest.TestCase):
                 master = Kannon(
                     api_instance=None,
                     template_job=client.V1Job(metadata=client.V1ObjectMeta()),
-                    job_prefix=None,
+                    job_prefix="",
                     path_child_script=__file__,  # just pass any existing file as dummy
                     env_to_inherit=None,
                 )
@@ -69,7 +69,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         super().tearDown()
         os.environ.clear()
 
-    def test_success_basic(self):
+    def test_success_basic(self) -> None:
 
         class Example(gokart.TaskOnKart):
             pass
@@ -79,7 +79,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         master = Kannon(
             api_instance=None,
             template_job=template_job,
-            job_prefix=None,
+            job_prefix="",
             path_child_script=__file__,  # just pass any existing file as dummy
             env_to_inherit=None,
         )
@@ -104,7 +104,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         self.assertEqual(len(child_env), 1)
         self.assertEqual(child_env[0], {"name": "TASK_WORKSPACE_DIRECTORY", "value": "/cache"})
 
-    def test_success_custom_env(self):
+    def test_success_custom_env(self) -> None:
 
         class Example(gokart.TaskOnKart):
             pass
@@ -114,7 +114,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         master = Kannon(
             api_instance=None,
             template_job=template_job,
-            job_prefix=None,
+            job_prefix="",
             path_child_script=__file__,  # just pass any existing file as dummy
             env_to_inherit=["TASK_WORKSPACE_DIRECTORY", "MY_ENV0", "MY_ENV1"],
         )
@@ -129,7 +129,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         self.assertEqual(child_env[1], {"name": "MY_ENV0", "value": "env0"})
         self.assertEqual(child_env[2], {"name": "MY_ENV1", "value": "env1"})
 
-    def test_fail_command_set(self):
+    def test_fail_command_set(self) -> None:
 
         class Example(gokart.TaskOnKart):
             pass
@@ -140,7 +140,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         master = Kannon(
             api_instance=None,
             template_job=template_job,
-            job_prefix=None,
+            job_prefix="",
             path_child_script=__file__,  # just pass any existing file as dummy
             env_to_inherit=None,
         )
@@ -149,7 +149,7 @@ class TestCreateChildJobObject(unittest.TestCase):
         with self.assertRaises(AssertionError):
             master._create_child_job_object("test-job", serialized_task)
 
-    def test_fail_default_env_not_exist(self):
+    def test_fail_default_env_not_exist(self) -> None:
 
         class Example(gokart.TaskOnKart):
             pass
@@ -163,7 +163,7 @@ class TestCreateChildJobObject(unittest.TestCase):
                 master = Kannon(
                     api_instance=None,
                     template_job=template_job,
-                    job_prefix=None,
+                    job_prefix="",
                     path_child_script=__file__,  # just pass any existing file as dummy
                     env_to_inherit=case,
                 )


### PR DESCRIPTION
from https://github.com/m3dev/kannon/pull/18#issuecomment-1505406772

Be strict 😃 

----

Big problem with current mypy configuration is that it won't check untyped function body.

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-check-untyped-defs

> By default the bodies of functions without annotations are not type checked.

So I strongly recommend to enable `--check-untyped-defs` at least.