### PR TITLE
Use OIDC publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   deploy:
-
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write  # this permission is mandatory for trusted publishing
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -19,9 +20,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install poetry poetry-dynamic-versioning twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Build
       run: |
-        poetry publish --build --username $TWINE_USERNAME --password $TWINE_PASSWORD
+        poetry build
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
> OpenID Connect (OIDC) provides a flexible, credential-free mechanism for delegating publishing authority for a PyPI package to a trusted third party service.

I think we should use OIDC instead of username and password.

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect