### PR TITLE
Fix job name generation

### DIFF
--- a/kannon/kube_util.py
+++ b/kannon/kube_util.py
@@ -13,6 +13,7 @@ class JobStatus(enum.Enum):
     SUCCEEDED = 1
     FAILED = 2
 
+
 # Max length of job name is 63.
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 JOB_NAME_MAX_LENGTH = 63

--- a/kannon/kube_util.py
+++ b/kannon/kube_util.py
@@ -31,8 +31,9 @@ def get_job_status(api_instance: client.BatchV1Api, job_name: str, namespace: st
 
 
 def gen_job_name(job_prefix: str) -> str:
-    job_name = f"{job_prefix}-{str(random.randint(0, 255)).zfill(3)}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
-    # TODO: validate job_name more precisely
-    job_name = job_name[:50]
+    job_suffix = f"{datetime.now().strftime('%Y%m%d%H%M%S')}-{str(random.randint(0, 255)).zfill(3)}"
+    job_prefix = job_prefix[:62 - len(job_suffix)]
+    job_name = f"{job_prefix}-{job_suffix}"
     job_name = job_name.replace("_", "-").lower()
+    job_name = job_name[:63]
     return job_name

--- a/kannon/kube_util.py
+++ b/kannon/kube_util.py
@@ -13,6 +13,10 @@ class JobStatus(enum.Enum):
     SUCCEEDED = 1
     FAILED = 2
 
+# Max length of job name is 63.
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+JOB_NAME_MAX_LENGTH = 63
+
 
 def create_job(api_instance: client.BatchV1Api, job: client.V1Job, namespace: str) -> None:
     api_response = api_instance.create_namespaced_job(
@@ -32,8 +36,8 @@ def get_job_status(api_instance: client.BatchV1Api, job_name: str, namespace: st
 
 def gen_job_name(job_prefix: str) -> str:
     job_suffix = f"{datetime.now().strftime('%Y%m%d%H%M%S')}-{str(random.randint(0, 255)).zfill(3)}"
-    job_prefix = job_prefix[:62 - len(job_suffix)]
+    job_prefix = job_prefix[:JOB_NAME_MAX_LENGTH - 1 - len(job_suffix)]
     job_name = f"{job_prefix}-{job_suffix}"
     job_name = job_name.replace("_", "-").lower()
-    job_name = job_name[:63]
+    job_name = job_name[:JOB_NAME_MAX_LENGTH]
     return job_name

--- a/kannon/master.py
+++ b/kannon/master.py
@@ -118,15 +118,14 @@ class Kannon:
         pkl_path = self._gen_pkl_path(task)
         make_target(pkl_path).dump(task)
         # Run on child job
-        job_name = gen_job_name(f"child-{task.get_task_family()}")
         job = self._create_child_job_object(
-            job_name=job_name,
+            job_name=self.job_prefix,
             task_pkl_path=pkl_path,
         )
         create_job(self.api_instance, job, self.namespace)
-        logger.info(f"Created child job {job_name} with task {self._gen_task_info(task)}")
+        logger.info(f"Created child job {self.job_prefix} with task {self._gen_task_info(task)}")
         task_unique_id = task.make_unique_id()
-        self.task_id_to_job_name[task_unique_id] = job_name
+        self.task_id_to_job_name[task_unique_id] = self.job_prefix
 
     def _create_child_job_object(self, job_name: str, task_pkl_path: str) -> client.V1Job:
         # TODO: use python -c to avoid dependency to execute_task.py

--- a/kannon/master.py
+++ b/kannon/master.py
@@ -118,14 +118,15 @@ class Kannon:
         pkl_path = self._gen_pkl_path(task)
         make_target(pkl_path).dump(task)
         # Run on child job
+        job_name = gen_job_name(self.job_prefix)
         job = self._create_child_job_object(
-            job_name=self.job_prefix,
+            job_name=job_name,
             task_pkl_path=pkl_path,
         )
         create_job(self.api_instance, job, self.namespace)
-        logger.info(f"Created child job {self.job_prefix} with task {self._gen_task_info(task)}")
+        logger.info(f"Created child job {job_name} with task {self._gen_task_info(task)}")
         task_unique_id = task.make_unique_id()
-        self.task_id_to_job_name[task_unique_id] = self.job_prefix
+        self.task_id_to_job_name[task_unique_id] = job_name
 
     def _create_child_job_object(self, job_name: str, task_pkl_path: str) -> client.V1Job:
         # TODO: use python -c to avoid dependency to execute_task.py

--- a/kannon/master.py
+++ b/kannon/master.py
@@ -118,7 +118,7 @@ class Kannon:
         pkl_path = self._gen_pkl_path(task)
         make_target(pkl_path).dump(task)
         # Run on child job
-        job_name = gen_job_name(f"{self.job_prefix}-{task.get_task_family()}")
+        job_name = gen_job_name(f"child-{task.get_task_family()}")
         job = self._create_child_job_object(
             job_name=job_name,
             task_pkl_path=pkl_path,


### PR DESCRIPTION
## What
Fix a way to generate job name.
- Validate a job name more precisely following the [k8s job name restriction](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)
- Improve readability of job names
- There is almost no conflicts